### PR TITLE
Fix discrepancies between candle chart timestamp indicator and x-axis

### DIFF
--- a/src/components/CandleChart/index.js
+++ b/src/components/CandleChart/index.js
@@ -162,7 +162,7 @@ const CandleStickChart = ({
           setLastBarText()
         } else {
           var price = param.seriesPrices.get(candleSeries).close
-          const time = dayjs.unix(param.time).format('MM/DD h:mm A')
+          const time = dayjs.utc(dayjs.unix(param.time)).format('MM/DD h:mm A')
           toolTip.innerHTML =
             `<div style="font-size: 22px; margin: 4px 0px; color: ${textColor}">` +
             valueFormatter(price) +

--- a/src/components/TokenChart/index.js
+++ b/src/components/TokenChart/index.js
@@ -94,7 +94,7 @@ const TokenChart = ({ address, color, base }) => {
     }
   }, [prevWindow, timeWindow])
 
-  // switch to daily data if switche to month or all time view
+  // switch to daily data if switched to month or all time view
   useEffect(() => {
     if (timeWindow === timeframeOptions.MONTH && prevWindow && prevWindow !== timeframeOptions.MONTH) {
       setFrequency(DATA_FREQUENCY.DAY)


### PR DESCRIPTION
The discrepancies noted in #3 happens because the time stamp displayed in the candle chart header is in local time while the time on the x-axis is converted to UTC. This ensures that both are consistent and in UTC