### PR TITLE
Fix and optimize historical price matching

### DIFF
--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -535,6 +535,7 @@ const getIntervalTokenData = async (tokenAddress, startTime, interval = 3600, la
       if (timestamp) {
         // TODO This is n^2, optimize
         for (let i = 0; i < timestampedPrices.length; i++) {
+          timestamp = parseInt(timestamp) * 1000
           if (timestampedPrices[i][0] > timestamp) {
             values[index].priceUSD = timestampedPrices[i][1] * values[index].derivedETH
             index += 1

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -531,16 +531,23 @@ const getIntervalTokenData = async (tokenAddress, startTime, interval = 3600, la
     // go through eth usd prices and assign to original values array
     let index = 0
     for (var brow in result) {
+      let startIndex = 0, endIndex = timestampedPrices.length - 1, found = -1
       let timestamp = brow.split('b')[1]
       if (timestamp) {
-        // TODO This is n^2, optimize
-        for (let i = 0; i < timestampedPrices.length; i++) {
-          timestamp = parseInt(timestamp) * 1000
-          if (timestampedPrices[i][0] > timestamp) {
-            values[index].priceUSD = timestampedPrices[i][1] * values[index].derivedETH
-            index += 1
-            break
+        timestamp = parseInt(timestamp) * 1000
+        while (startIndex <= endIndex) {
+          let middleIndex = (startIndex + endIndex) >> 1
+          if (timestampedPrices[middleIndex][0] <= timestamp) {
+            startIndex = middleIndex + 1
           }
+          else {
+            found = middleIndex
+            endIndex = middleIndex - 1
+          }
+        }
+        if (found >= 0) {
+          values[index].priceUSD = timestampedPrices[found][1] * values[index].derivedETH
+          index += 1
         }
       }
     }


### PR DESCRIPTION
Unless I am mistaken, there was a type mismatch in the original loop that matches eth and eth usd prices by timestamp. In
`if (timestampedPrices[i][0] > timestamp) {`, `timestamp` is a string containing a timestamp in seconds but `timestampedPrices[middleIndex][0]` is an integer containing a timestamp in milliseconds. I've converted `timestamp` accordingly to make the comparison meaningful.

The original approach was doing a linear search to match the timestamps. The eth timestamp array is ordered so I switched to a binary search which generally proves faster, especially when the array is large.