### PR TITLE
Fix liquidity price conversion and fees calculation

### DIFF
--- a/src/contexts/User.js
+++ b/src/contexts/User.js
@@ -289,6 +289,17 @@ export function useUserPositionChart(position, account) {
         pairSnapshots,
         currentETHPrice
       )
+      if (fetchedData) {
+        for (let j = 0; j < fetchedData.length; j++) {
+          let latestAvaxPrice
+          if (j === fetchedData.length - 1) {
+            latestAvaxPrice = await getCurrentEthPrice()
+          } else {
+            latestAvaxPrice = await getEthPriceAtDate(fetchedData[j].date)
+          }
+          fetchedData[j].usdValue = fetchedData[j].usdValue * latestAvaxPrice
+        }
+      }
       updateUserPairReturns(account, pairAddress, fetchedData)
     }
     if (
@@ -314,25 +325,6 @@ export function useUserPositionChart(position, account) {
     updateUserPairReturns,
     position.pair.id,
   ])
-
-  const convertPrice = async function () {
-    if (formattedHistory) {
-      for (let j = 0; j < formattedHistory.length; j++) {
-        let latestAvaxPrice
-        if (j === formattedHistory.length - 1) {
-          latestAvaxPrice = await getCurrentEthPrice()
-        } else {
-          latestAvaxPrice = await getEthPriceAtDate(formattedHistory[j].date)
-        }
-        formattedHistory[j].usdValue = formattedHistory[j].usdValue * latestAvaxPrice
-      }
-    }
-    return formattedHistory
-  }
-
-  if (formattedHistory) {
-    convertPrice().then(result => { console.log("Finished waiting") })
-  }
 
   return formattedHistory
 }

--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -109,8 +109,16 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
   positionT1 = formatPricesForEarlyTimestamps(positionT1)
 
   // calculate ownership at ends of window, for end of window we need original LP token balance / new total supply
-  const t0Ownership = positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
-  const t1Ownership = positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+  // eslint-disable-next-line eqeqeq
+  const t0Ownership =
+      positionT0.liquidityTokenTotalSupply != 0
+          ? positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
+          : 0
+  // eslint-disable-next-line eqeqeq
+  const t1Ownership =
+      positionT1.liquidityTokenTotalSupply != 0
+          ? positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+          : 0
 
   // get starting amounts of token0 and token1 deposited by LP
   const token0_amount_t0 = t0Ownership * positionT0.reserve0


### PR DESCRIPTION
**Fix 1:** The values displayed on the user account chart for liquidity on specific pools were equal to `avax_amount * avax_price * avax_price` instead of just `avax_amonut * avax_price` due to a race condition (#13). This fixes it

**Fix 2:** This is for an issue originally raised on [Uniswap](https://github.com/Uniswap/uniswap-info/issues/363). The Pangolin code is the same so the issue is also present here. 
If an account is the first to provide liquidity on a pair, the calculation of their ownership of the pool when they entered it will return a `NaN` because it will try to divide by a `liquidityTokenTotalSupply` that is equal to 0. The ownership `NaN` at t0 will then affect all subsequent calculations, including the sum of fees. Consequently the fees will not be displayed on the interface. Note: this should not affect #14 on which another user is currently working.