### PR TITLE
Feature/swap eth references for avax and remove usd multiplication by price

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -4,7 +4,7 @@ import { HttpLink } from 'apollo-link-http'
 
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://graph-node.avax.network/subgraphs/name/dasconnor/pangolindex',
+    uri: 'https://api.thegraph.com/subgraphs/name/dasconnor/pangolin-historical-pricing',
   }),
   cache: new InMemoryCache(),
   shouldBatch: true,

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -40,7 +40,6 @@ export const V1_DATA_QUERY = gql`
       totalLiquidityUSD
       txCount
     }
-    // TODO: not touching this b/c this is a UniSwap specific query that is no longer used; may want to remove entirely
     exchanges(first: 200, orderBy: ethBalance, orderDirection: desc) {
       ethBalance
     }

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -40,6 +40,7 @@ export const V1_DATA_QUERY = gql`
       totalLiquidityUSD
       txCount
     }
+    // TODO: not touching this b/c this is a UniSwap specific query that is no longer used; may want to remove entirely
     exchanges(first: 200, orderBy: ethBalance, orderDirection: desc) {
       ethBalance
     }
@@ -122,7 +123,7 @@ export const PRICES_BY_BLOCK = (tokenAddress, blocks) => {
   queryString += blocks.map(
     (block) => `
       t${block.timestamp}:token(id:"${tokenAddress}", block: { number: ${block.number} }) { 
-        derivedETH
+        derivedAVAX
       }
     `
   )
@@ -130,7 +131,7 @@ export const PRICES_BY_BLOCK = (tokenAddress, blocks) => {
   queryString += blocks.map(
     (block) => `
       b${block.timestamp}: bundle(id:"1", block: { number: ${block.number} }) { 
-        ethPrice
+        avaxPrice
       }
     `
   )
@@ -178,10 +179,10 @@ export const SHARE_VALUE = (pairAddress, blocks) => {
         reserveUSD
         totalSupply 
         token0{
-          derivedETH
+          derivedAVAX
         }
         token1{
-          derivedETH
+          derivedAVAX
         }
       }
     `
@@ -190,7 +191,7 @@ export const SHARE_VALUE = (pairAddress, blocks) => {
   queryString += blocks.map(
     (block) => `
       b${block.timestamp}: bundle(id:"1", block: { number: ${block.number} }) { 
-        ethPrice
+        avaxPrice
       }
     `
   )
@@ -199,20 +200,20 @@ export const SHARE_VALUE = (pairAddress, blocks) => {
   return gql(queryString)
 }
 
-export const ETH_PRICE = (block) => {
+export const AVAX_PRICE = (block) => {
   const queryString = block
     ? `
     query bundles {
       bundles(where: { id: ${BUNDLE_ID} } block: {number: ${block}}) {
         id
-        ethPrice
+        avaxPrice
       }
     }
   `
     : ` query bundles {
       bundles(where: { id: ${BUNDLE_ID} }) {
         id
-        ethPrice
+        avaxPrice
       }
     }
   `
@@ -309,12 +310,12 @@ export const USER_POSITIONS = gql`
         token0 {
           id
           symbol
-          derivedETH
+          derivedAVAX
         }
         token1 {
           id
           symbol
-          derivedETH
+          derivedAVAX
         }
         totalSupply
       }
@@ -451,9 +452,9 @@ export const GLOBAL_CHART = gql`
       date
       totalVolumeUSD
       dailyVolumeUSD
-      dailyVolumeETH
+      dailyVolumeAVAX
       totalLiquidityUSD
-      totalLiquidityETH
+      totalLiquidityAVAX
     }
   }
 `
@@ -465,10 +466,10 @@ export const GLOBAL_DATA = (block) => {
        where: { id: "${FACTORY_ADDRESS}" }) {
         id
         totalVolumeUSD
-        totalVolumeETH
+        totalVolumeAVAX
         untrackedVolumeUSD
         totalLiquidityUSD
-        totalLiquidityETH
+        totalLiquidityAVAX
         txCount
         pairCount
       }
@@ -627,7 +628,7 @@ export const PAIR_SEARCH = gql`
 
 export const ALL_PAIRS = gql`
   query pairs($skip: Int!) {
-    pairs(first: 500, skip: $skip, orderBy: trackedReserveETH, orderDirection: desc) {
+    pairs(first: 500, skip: $skip, orderBy: trackedReserveAVAX, orderDirection: desc) {
       id
       token0 {
         id
@@ -652,21 +653,21 @@ const PairFields = `
       symbol
       name
       totalLiquidity
-      derivedETH
+      derivedAVAX
     }
     token1 {
       id
       symbol
       name
       totalLiquidity
-      derivedETH
+      derivedAVAX
     }
     reserve0
     reserve1
     reserveUSD
     totalSupply
-    trackedReserveETH
-    reserveETH
+    trackedReserveAVAX
+    reserveAVAX
     volumeUSD
     untrackedVolumeUSD
     token0Price
@@ -677,7 +678,7 @@ const PairFields = `
 
 export const PAIRS_CURRENT = gql`
   query pairs {
-    pairs(first: 200, orderBy: trackedReserveETH, orderDirection: desc) {
+    pairs(first: 200, orderBy: trackedReserveAVAX, orderDirection: desc) {
       id
     }
   }
@@ -721,7 +722,7 @@ export const MINING_POSITIONS = (account) => {
 export const PAIRS_BULK = gql`
   ${PairFields}
   query pairs($allPairs: [Bytes]!) {
-    pairs(where: { id_in: $allPairs }, orderBy: trackedReserveETH, orderDirection: desc) {
+    pairs(where: { id_in: $allPairs }, orderBy: trackedReserveAVAX, orderDirection: desc) {
       ...PairFields
     }
   }
@@ -735,10 +736,10 @@ export const PAIRS_HISTORICAL_BULK = (block, pairs) => {
   pairsString += ']'
   let queryString = `
   query pairs {
-    pairs(first: 200, where: {id_in: ${pairsString}}, block: {number: ${block}}, orderBy: trackedReserveETH, orderDirection: desc) {
+    pairs(first: 200, where: {id_in: ${pairsString}}, block: {number: ${block}}, orderBy: trackedReserveAVAX, orderDirection: desc) {
       id
       reserveUSD
-      trackedReserveETH
+      trackedReserveAVAX
       volumeUSD
       untrackedVolumeUSD
     }
@@ -755,8 +756,8 @@ export const TOKEN_CHART = gql`
       priceUSD
       totalLiquidityToken
       totalLiquidityUSD
-      totalLiquidityETH
-      dailyVolumeETH
+      totalLiquidityAVAX
+      dailyVolumeAVAX
       dailyVolumeToken
       dailyVolumeUSD
     }
@@ -768,7 +769,7 @@ const TokenFields = `
     id
     name
     symbol
-    derivedETH
+    derivedAVAX
     tradeVolume
     tradeVolumeUSD
     untrackedVolumeUSD

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -63,8 +63,8 @@ const Chart = ({ data, chartOption, currencyUnit, symbol }) => {
               strokeWidth={2}
               dot={false}
               type="monotone"
-              name={currencyUnit === 'ETH' ? 'Price (ETH/' + symbol + ')' : 'Price (USD/' + symbol + ')'}
-              dataKey={currencyUnit === 'ETH' ? 'ethPerToken' : 'tokenPriceUSD'}
+              name={currencyUnit === 'AVAX' ? 'Price (AVAX/' + symbol + ')' : 'Price (USD/' + symbol + ')'}
+              dataKey={currencyUnit === 'AVAX' ? 'avaxPerToken' : 'tokenPriceUSD'}
               yAxisId={2}
               fill="var(--c-token)"
               opacity={'0.4'}
@@ -74,8 +74,8 @@ const Chart = ({ data, chartOption, currencyUnit, symbol }) => {
               strokeWidth={2}
               dot={false}
               type="monotone"
-              name={currencyUnit === 'USD' ? 'Inverse (' + symbol + '/USD)' : 'Inverse (' + symbol + '/ETH)'}
-              dataKey={currencyUnit === 'USD' ? 'tokensPerUSD' : 'tokensPerEth'}
+              name={currencyUnit === 'USD' ? 'Inverse (' + symbol + '/USD)' : 'Inverse (' + symbol + '/AVAX)'}
+              dataKey={currencyUnit === 'USD' ? 'tokensPerUSD' : 'tokensPerAvax'}
               yAxisId={3}
               fill="var(--c-token)"
               opacity={'0'}
@@ -153,8 +153,8 @@ const Chart = ({ data, chartOption, currencyUnit, symbol }) => {
               strokeWidth={2}
               dot={false}
               type="monotone"
-              name={'Total Liquidity' + (currencyUnit === 'USD' ? ' (USD)' : ' (ETH)')}
-              dataKey={currencyUnit === 'USD' ? 'usdLiquidity' : 'ethLiquidity'}
+              name={'Total Liquidity' + (currencyUnit === 'USD' ? ' (USD)' : ' (AVAX)')}
+              dataKey={currencyUnit === 'USD' ? 'usdLiquidity' : 'avaxLiquidity'}
               yAxisId={0}
               fill="var(--c-token)"
               opacity={'0.4'}
@@ -162,8 +162,8 @@ const Chart = ({ data, chartOption, currencyUnit, symbol }) => {
             />
             <Area
               type="monotone"
-              name={'Eth Balance'}
-              dataKey={'ethBalance'}
+              name={'Avax Balance'}
+              dataKey={'avaxBalance'}
               fill="var(--c-token)"
               opacity={'0'}
               stroke="var(--c-token)"
@@ -222,8 +222,8 @@ const Chart = ({ data, chartOption, currencyUnit, symbol }) => {
             />
             <Bar
               type="monotone"
-              name={'Volume' + (currencyUnit === 'USD' ? ' (USD)' : ' (ETH)')}
-              dataKey={currencyUnit === 'USD' ? 'usdVolume' : 'ethVolume'}
+              name={'Volume' + (currencyUnit === 'USD' ? ' (USD)' : ' (AVAX)')}
+              dataKey={currencyUnit === 'USD' ? 'usdVolume' : 'avaxVolume'}
               fill="var(--c-token)"
               opacity={'0.4'}
               yAxisId={0}

--- a/src/components/CurrencySelect/index.js
+++ b/src/components/CurrencySelect/index.js
@@ -46,7 +46,7 @@ const CurrencySelect = () => {
 
   const getOther = () => {
     if (currency === 'USD') {
-      return 'ETH'
+      return 'AVAX'
     } else {
       return 'USD'
     }

--- a/src/components/GlobalStats/index.js
+++ b/src/components/GlobalStats/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { RowFixed, RowBetween } from '../Row'
 import { useMedia } from 'react-use'

--- a/src/components/GlobalStats/index.js
+++ b/src/components/GlobalStats/index.js
@@ -5,6 +5,7 @@ import { useMedia } from 'react-use'
 import { useGlobalData, useAvaxPrice } from '../../contexts/GlobalData'
 import { formattedNum, localNumber } from '../../utils'
 
+import PngPrice from '../PngPrice'
 import { TYPE } from '../../Theme'
 
 const Header = styled.div`
@@ -24,6 +25,8 @@ export default function GlobalStats() {
   const below400 = useMedia('(max-width: 400px)')
   const below816 = useMedia('(max-width: 816px)')
 
+  const [showPriceCard, setShowPriceCard] = useState(false)
+
   const { oneDayVolumeUSD, oneDayTxns, pairCount } = useGlobalData()
   const [avaxPrice] = useAvaxPrice()
   const formattedAvaxPrice = avaxPrice ? formattedNum(avaxPrice, true) : '-'
@@ -34,8 +37,18 @@ export default function GlobalStats() {
       <RowBetween style={{ padding: below816 ? '0.5rem' : '.5rem' }}>
         <RowFixed>
           {!below400 && (
-            <TYPE.main mr={'1rem'} style={{ position: 'relative' }}>
+            <TYPE.main
+              mr={'1rem'} 
+              onMouseEnter={() => {
+                setShowPriceCard(true)
+              }}
+              onMouseLeave={() => {
+                setShowPriceCard(false)
+              }}
+              style={{ position: 'relative' }}
+            >
               AVAX Price: <Medium>{formattedAvaxPrice}</Medium>
+              {showPriceCard && <PngPrice />}
             </TYPE.main>
           )}
 

--- a/src/components/GlobalStats/index.js
+++ b/src/components/GlobalStats/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { RowFixed, RowBetween } from '../Row'
 import { useMedia } from 'react-use'
-import { useGlobalData, useEthPrice } from '../../contexts/GlobalData'
+import { useGlobalData, useAvaxPrice } from '../../contexts/GlobalData'
 import { formattedNum, localNumber } from '../../utils'
 
 import { TYPE } from '../../Theme'
@@ -25,8 +25,8 @@ export default function GlobalStats() {
   const below816 = useMedia('(max-width: 816px)')
 
   const { oneDayVolumeUSD, oneDayTxns, pairCount } = useGlobalData()
-  const [ethPrice] = useEthPrice()
-  const formattedEthPrice = ethPrice ? formattedNum(ethPrice, true) : '-'
+  const [avaxPrice] = useAvaxPrice()
+  const formattedAvaxPrice = avaxPrice ? formattedNum(avaxPrice, true) : '-'
   const oneDayFees = oneDayVolumeUSD ? formattedNum(oneDayVolumeUSD * 0.003, true) : ''
 
   return (
@@ -35,7 +35,7 @@ export default function GlobalStats() {
         <RowFixed>
           {!below400 && (
             <TYPE.main mr={'1rem'} style={{ position: 'relative' }}>
-              AVAX Price: <Medium>{formattedEthPrice}</Medium>
+              AVAX Price: <Medium>{formattedAvaxPrice}</Medium>
             </TYPE.main>
           )}
 

--- a/src/components/PngPrice/index.js
+++ b/src/components/PngPrice/index.js
@@ -23,38 +23,30 @@ function formatPercent(rawPercent) {
   } else return parseFloat(rawPercent * 100).toFixed(0) + '%'
 }
 
-export default function UniPrice() {
-  const daiPair = usePairData('0xa478c2975ab1ea89e8196811f51a7b7ade33eb11')
-  const usdcPair = usePairData('0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc')
-  const usdtPair = usePairData('0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852')
+export default function PngPrice() {
+  const daiPair = usePairData('0x17a2E8275792b4616bEFb02EB9AE699aa0DCb94b')  // dai is token1
+  const usdtPair = usePairData('0x9EE0a4E21bd333a6bb2ab298194320b8DaA26516')  // usdt is token1
 
   const totalLiquidity = useMemo(() => {
-    return daiPair && usdcPair && usdtPair
-      ? daiPair.trackedReserveUSD + usdcPair.trackedReserveUSD + usdtPair.trackedReserveUSD
+    return daiPair && usdtPair
+      ? daiPair.trackedReserveUSD + usdtPair.trackedReserveUSD
       : 0
-  }, [daiPair, usdcPair, usdtPair])
+  }, [daiPair, usdtPair])
 
-  const daiPerEth = daiPair ? parseFloat(daiPair.token0Price).toFixed(2) : '-'
-  const usdcPerEth = usdcPair ? parseFloat(usdcPair.token0Price).toFixed(2) : '-'
-  const usdtPerEth = usdtPair ? parseFloat(usdtPair.token1Price).toFixed(2) : '-'
+  const daiPerAvax = daiPair ? parseFloat(daiPair.token1Price).toFixed(2) : '-'
+  const usdtPerAvax = usdtPair ? parseFloat(usdtPair.token1Price).toFixed(2) : '-'
 
   return (
     <PriceCard>
       <AutoColumn gap="10px">
         <RowFixed>
-          <TYPE.main>DAI/ETH: {formattedNum(daiPerEth, true)}</TYPE.main>
+          <TYPE.main>DAI/AVAX: {formattedNum(daiPerAvax, true)}</TYPE.main>
           <TYPE.light style={{ marginLeft: '10px' }}>
             {daiPair && totalLiquidity ? formatPercent(daiPair.trackedReserveUSD / totalLiquidity) : '-'}
           </TYPE.light>
         </RowFixed>
         <RowFixed>
-          <TYPE.main>USDC/ETH: {formattedNum(usdcPerEth, true)}</TYPE.main>
-          <TYPE.light style={{ marginLeft: '10px' }}>
-            {usdcPair && totalLiquidity ? formatPercent(usdcPair.trackedReserveUSD / totalLiquidity) : '-'}
-          </TYPE.light>
-        </RowFixed>
-        <RowFixed>
-          <TYPE.main>USDT/ETH: {formattedNum(usdtPerEth, true)}</TYPE.main>
+          <TYPE.main>USDT/AVAX: {formattedNum(usdtPerAvax, true)}</TYPE.main>
           <TYPE.light style={{ marginLeft: '10px' }}>
             {usdtPair && totalLiquidity ? formatPercent(usdtPair.trackedReserveUSD / totalLiquidity) : '-'}
           </TYPE.light>

--- a/src/components/PositionList/index.js
+++ b/src/components/PositionList/index.js
@@ -11,7 +11,7 @@ import DoubleTokenLogo from '../DoubleLogo'
 import { withRouter } from 'react-router-dom'
 import { formattedNum, getPoolLink } from '../../utils'
 import { AutoColumn } from '../Column'
-import { useEthPrice } from '../../contexts/GlobalData'
+import { useAvaxPrice } from '../../contexts/GlobalData'
 import { RowFixed } from '../Row'
 import { ButtonLight } from '../ButtonStyled'
 import { TYPE } from '../../Theme'
@@ -135,11 +135,11 @@ function PositionList({ positions }) {
     }
   }, [positions])
 
-  const [ethPrice] = useEthPrice()
+  const [avaxPrice] = useAvaxPrice()
 
   const ListItem = ({ position, index }) => {
     const poolOwnership = position.liquidityTokenBalance / position.pair.totalSupply
-    const valueUSD = poolOwnership * position.pair.reserveUSD * ethPrice
+    const valueUSD = poolOwnership * position.pair.reserveUSD
 
     return (
       <DashGrid style={{ opacity: poolOwnership > 0 ? 1 : 0.6 }} focus={true}>
@@ -212,9 +212,9 @@ function PositionList({ positions }) {
               <AutoColumn gap="4px" justify="flex-end">
                 <RowFixed>
                   <TYPE.small fontWeight={400}>
-                    {parseFloat(position.pair.token0.derivedETH)
+                    {parseFloat(position.pair.token0.derivedAVAX)
                       ? formattedNum(
-                        position?.fees.sum / (parseFloat(position.pair.token0.derivedETH) * ethPrice) / 2,
+                        position?.fees.sum / (parseFloat(position.pair.token0.derivedAVAX) * avaxPrice) / 2,
                         false,
                         true
                       )
@@ -229,9 +229,9 @@ function PositionList({ positions }) {
                 </RowFixed>
                 <RowFixed>
                   <TYPE.small fontWeight={400}>
-                    {parseFloat(position.pair.token1.derivedETH)
+                    {parseFloat(position.pair.token1.derivedAVAX)
                       ? formattedNum(
-                        position?.fees.sum / (parseFloat(position.pair.token1.derivedETH) * ethPrice) / 2,
+                        position?.fees.sum / (parseFloat(position.pair.token1.derivedAVAX) * avaxPrice) / 2,
                         false,
                         true
                       )

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -315,13 +315,13 @@ export const Search = ({ small = false }) => {
         .sort((a, b) => {
           const pairA = allPairData[a.id]
           const pairB = allPairData[b.id]
-          if (pairA?.trackedReserveETH && pairB?.trackedReserveETH) {
-            return parseFloat(pairA.trackedReserveETH) > parseFloat(pairB.trackedReserveETH) ? -1 : 1
+          if (pairA?.trackedReserveAVAX && pairB?.trackedReserveAVAX) {
+            return parseFloat(pairA.trackedReserveAVAX) > parseFloat(pairB.trackedReserveAVAX) ? -1 : 1
           }
-          if (pairA?.trackedReserveETH && !pairB?.trackedReserveETH) {
+          if (pairA?.trackedReserveAVAX && !pairB?.trackedReserveAVAX) {
             return -1
           }
-          if (!pairA?.trackedReserveETH && pairB?.trackedReserveETH) {
+          if (!pairA?.trackedReserveAVAX && pairB?.trackedReserveAVAX) {
             return 1
           }
           return 0

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -63,7 +63,7 @@ function customFilter(option, searchText) {
   return option.data.label.toString().toLowerCase().includes(searchText.toString().toLowerCase())
 }
 
-const Select = ({ options, onChange, setCapEth, capEth, tokenSelect = false, placeholder, ...rest }) => {
+const Select = ({ options, onChange, setCapAvax, capAvax, tokenSelect = false, placeholder, ...rest }) => {
   return tokenSelect ? (
     <ReactSelect
       placeholder={placeholder}
@@ -93,9 +93,9 @@ const Select = ({ options, onChange, setCapEth, capEth, tokenSelect = false, pla
                 <input
                   name="isGoing"
                   type="checkbox"
-                  checked={capEth}
+                  checked={capAvax}
                   onChange={() => {
-                    setCapEth(!capEth)
+                    setCapAvax(!capAvax)
                   }}
                 />
                 Hide Low Liquidity

--- a/src/components/TradingviewChart/index.js
+++ b/src/components/TradingviewChart/index.js
@@ -8,7 +8,6 @@ import { usePrevious } from 'react-use'
 import { Play } from 'react-feather'
 import { useDarkModeManager } from '../../contexts/LocalStorage'
 import { IconWrapper } from '..'
-import { useAvaxPrice } from '../../contexts/GlobalData'
 
 dayjs.extend(utc)
 
@@ -40,8 +39,6 @@ const TradingViewChart = ({
   // pointer to the chart object
   const [chartCreated, setChartCreated] = useState(false)
   const dataPrev = usePrevious(data)
-
-  let avaxPrice = useAvaxPrice()[0]
 
   useEffect(() => {
     if (data !== dataPrev && chartCreated && type === CHART_TYPES.BAR) {

--- a/src/components/TradingviewChart/index.js
+++ b/src/components/TradingviewChart/index.js
@@ -58,7 +58,7 @@ const TradingViewChart = ({
   const formattedData = data?.map((entry) => {
     return {
       time: dayjs.unix(entry.date).utc().format('YYYY-MM-DD'),
-      value: parseFloat(entry[field]) * avaxPrice,  // TODO: is entry[field] already in USD?
+      value: parseFloat(entry[field]),
     }
   })
 

--- a/src/components/TradingviewChart/index.js
+++ b/src/components/TradingviewChart/index.js
@@ -8,7 +8,7 @@ import { usePrevious } from 'react-use'
 import { Play } from 'react-feather'
 import { useDarkModeManager } from '../../contexts/LocalStorage'
 import { IconWrapper } from '..'
-import { useEthPrice } from '../../contexts/GlobalData'
+import { useAvaxPrice } from '../../contexts/GlobalData'
 
 dayjs.extend(utc)
 
@@ -41,7 +41,7 @@ const TradingViewChart = ({
   const [chartCreated, setChartCreated] = useState(false)
   const dataPrev = usePrevious(data)
 
-  let ethPrice = useEthPrice()[0]
+  let avaxPrice = useAvaxPrice()[0]
 
   useEffect(() => {
     if (data !== dataPrev && chartCreated && type === CHART_TYPES.BAR) {
@@ -58,7 +58,7 @@ const TradingViewChart = ({
   const formattedData = data?.map((entry) => {
     return {
       time: dayjs.unix(entry.date).utc().format('YYYY-MM-DD'),
-      value: parseFloat(entry[field]) * ethPrice,
+      value: parseFloat(entry[field]) * avaxPrice,  // TODO: is entry[field] already in USD?
     }
   })
 

--- a/src/components/TxnList/index.js
+++ b/src/components/TxnList/index.js
@@ -16,7 +16,6 @@ import DropdownSelect from '../DropdownSelect'
 import FormattedName from '../FormattedName'
 import { TYPE } from '../../Theme'
 import { updateNameData } from '../../utils/data'
-import { useAvaxPrice } from '../../contexts/GlobalData'
 
 dayjs.extend(utc)
 
@@ -181,8 +180,6 @@ function TxnList({ transactions, symbol0Override, symbol1Override, color }) {
     setPage(1)
   }, [transactions])
 
-  const [avaxPrice] = useAvaxPrice()
-
   // parse the txns and format for UI
   useEffect(() => {
     if (transactions && transactions.mints && transactions.burns && transactions.swaps) {
@@ -263,7 +260,7 @@ function TxnList({ transactions, symbol0Override, symbol1Override, color }) {
         setMaxPage(Math.floor(filtered.length / ITEMS_PER_PAGE) + extraPages)
       }
     }
-  }, [transactions, txFilter, avaxPrice])  // TODO: I think we can remove this? I don't think it gets used
+  }, [transactions, txFilter])
 
   useEffect(() => {
     setPage(1)

--- a/src/components/TxnList/index.js
+++ b/src/components/TxnList/index.js
@@ -16,7 +16,7 @@ import DropdownSelect from '../DropdownSelect'
 import FormattedName from '../FormattedName'
 import { TYPE } from '../../Theme'
 import { updateNameData } from '../../utils/data'
-import { useEthPrice } from '../../contexts/GlobalData'
+import { useAvaxPrice } from '../../contexts/GlobalData'
 
 dayjs.extend(utc)
 
@@ -181,7 +181,7 @@ function TxnList({ transactions, symbol0Override, symbol1Override, color }) {
     setPage(1)
   }, [transactions])
 
-  const [ethPrice] = useEthPrice()
+  const [avaxPrice] = useAvaxPrice()
 
   // parse the txns and format for UI
   useEffect(() => {
@@ -263,7 +263,7 @@ function TxnList({ transactions, symbol0Override, symbol1Override, color }) {
         setMaxPage(Math.floor(filtered.length / ITEMS_PER_PAGE) + extraPages)
       }
     }
-  }, [transactions, txFilter, ethPrice])
+  }, [transactions, txFilter, avaxPrice])  // TODO: I think we can remove this? I don't think it gets used
 
   useEffect(() => {
     setPage(1)
@@ -291,7 +291,7 @@ function TxnList({ transactions, symbol0Override, symbol1Override, color }) {
           </Link>
         </DataText>
         <DataText area="value">
-          {currency === 'ETH' ? 'Ξ ' + formattedNum(item.valueETH) : formattedNum(item.amountUSD, true)}
+          {currency === 'AVAX' ? 'Ξ ' + formattedNum(item.valueAVAX) : formattedNum(item.amountUSD, true)}
         </DataText>
         {!below780 && (
           <>

--- a/src/contexts/Application.js
+++ b/src/contexts/Application.js
@@ -199,10 +199,10 @@ export function useLatestBlocks() {
 export function useCurrentCurrency() {
   const [state, { update }] = useApplicationContext()
   const toggleCurrency = useCallback(() => {
-    if (state.currency === 'ETH') {
+    if (state.currency === 'AVAX') {
       update('USD')
     } else {
-      update('ETH')
+      update('AVAX')
     }
   }, [state, update])
   return [state[CURRENCY], toggleCurrency]

--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -267,9 +267,6 @@ async function getGlobalData(avaxPrice, oldAvaxPrice) {
     if (data) {
       //if (data && oneDayData && twoDayData && twoWeekData) {
 
-      // format the total liquidity in USD
-      data.totalLiquidityUSD = data.totalLiquidityAVAX * avaxPrice
-
       if (oneDayData && twoDayData) {
         let [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
           data.totalVolumeUSD,
@@ -294,8 +291,8 @@ async function getGlobalData(avaxPrice, oldAvaxPrice) {
         }
 
         const liquidityChangeUSD = getPercentChange(
-          data.totalLiquidityAVAX * avaxPrice,
-          oneDayData.totalLiquidityAVAX * oldAvaxPrice
+          data.totalLiquidityUSD,
+          oneDayData.totalLiquidityUSD
         )
         data.liquidityChangeUSD = liquidityChangeUSD
 
@@ -358,7 +355,7 @@ const getChartData = async (oldestDateToFetch, avaxPrice) => {
 
       // fill in empty days ( there will be no day datas if no trades made that day )
       let timestamp = data[0].date ? data[0].date : oldestDateToFetch
-      let latestLiquidityUSD = data[0].totalLiquidityAVAX * avaxPrice
+      let latestLiquidityUSD = data[0].totalLiquidityUSD
       let latestDayDats = data[0].mostLiquidTokens
       let index = 1
       while (timestamp < utcEndTime.unix() - oneDay) {

--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -443,7 +443,7 @@ const getGlobalTransactions = async () => {
  */
 const getAvaxPrice = async () => {
   const utcCurrentTime = dayjs()
-  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').startOf('minute').unix() * 1000
+  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').startOf('minute').unix()
 
   let avaxPrice = 0
   let avaxPriceOneDay = 0

--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -205,10 +205,12 @@ export default function Provider({ children }) {
 
 /**
  * Gets all the global data for the overview page.
- * Needs current avax price to compute liquidity in USD.
+ * Needs current avax price to compute liquidity in USD and
+ * oldAvaxPrice to get 24 hour USD changes.
  * @param {*} avaxPrice
+ * @param {*} oldAvaxPrice
  */
-async function getGlobalData(avaxPrice) {
+async function getGlobalData(avaxPrice, oldAvaxPrice) {
   // data for each day , historic data used for % changes
   let data = {}
   let oneDayData = {}
@@ -292,8 +294,8 @@ async function getGlobalData(avaxPrice) {
         }
 
         const liquidityChangeUSD = getPercentChange(
-          data.totalLiquidityAVAX,
-          oneDayData.totalLiquidityAVAX
+          data.totalLiquidityAVAX * avaxPrice,
+          oneDayData.totalLiquidityAVAX * oldAvaxPrice
         )
         data.liquidityChangeUSD = liquidityChangeUSD
 
@@ -551,13 +553,13 @@ async function getAllTokensOnUniswap() {
  */
 export function useGlobalData() {
   const [state, { update, updateAllPairsInUniswap, updateAllTokensInUniswap }] = useGlobalDataContext()
-  const [avaxPrice] = useAvaxPrice()
+  const [avaxPrice, oldAvaxPrice] = useAvaxPrice()
 
   const data = state?.globalData
 
   useEffect(() => {
     async function fetchData() {
-      let globalData = await getGlobalData(avaxPrice)
+      let globalData = await getGlobalData(avaxPrice, oldAvaxPrice)
       globalData && update(globalData)
 
       let allPairs = await getAllPairsOnUniswap()
@@ -569,7 +571,7 @@ export function useGlobalData() {
     if (!data && avaxPrice) {
       fetchData()
     }
-  }, [avaxPrice, update, data, updateAllPairsInUniswap, updateAllTokensInUniswap])
+  }, [avaxPrice, oldAvaxPrice, update, data, updateAllPairsInUniswap, updateAllTokensInUniswap])
 
   return data || {}
 }

--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -5,6 +5,7 @@ import utc from 'dayjs/plugin/utc'
 import { useTimeframe } from './Application'
 import {
   getPercentChange,
+  getBlockFromTimestamp,
   getBlocksFromTimestamps,
   get2DayPercentChange,
   getTimeframe,
@@ -461,7 +462,7 @@ const getAvaxPrice = async () => {
     })
     avaxPrice = result?.data?.bundles[0]?.avaxPrice
     avaxPriceOneDay = resultOneDay?.data?.bundles[0]?.avaxPrice
-    priceChangeAVAX = getPercentChange(currentPrice, oneDayBackPrice)
+    priceChangeAVAX = getPercentChange(avaxPrice, avaxPriceOneDay)
   } catch (e) {
     console.log(e)
   }

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -270,8 +270,8 @@ const getTopTokens = async (avaxPrice, avaxPriceOld) => {
           twoDayHistory?.txCount ?? 0
         )
 
-        const currentLiquidityUSD = data?.totalLiquidity * avaxPrice * data?.derivedAVAX
-        const oldLiquidityUSD = oneDayHistory?.totalLiquidity * avaxPriceOld * oneDayHistory?.derivedAVAX
+        const currentLiquidityUSD = data?.totalLiquidityUSD
+        const oldLiquidityUSD = oneDayHistory?.totalLiquidityUSD
 
         // percent changes
         const priceChangeUSD = getPercentChange(
@@ -401,8 +401,8 @@ const getTokenData = async (address, avaxPrice, avaxPriceOld) => {
       parseFloat(oneDayData?.derivedAVAX ?? 0) * avaxPriceOld
     )
 
-    const currentLiquidityUSD = data?.totalLiquidity * avaxPrice * data?.derivedAVAX
-    const oldLiquidityUSD = oneDayData?.totalLiquidity * avaxPriceOld * oneDayData?.derivedAVAX
+    const currentLiquidityUSD = data?.totalLiquidityUSD
+    const oldLiquidityUSD = oneDayData?.totalLiquidityUSD
 
     // set data
     data.priceUSD = data?.derivedAVAX * avaxPrice

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -270,8 +270,8 @@ const getTopTokens = async (avaxPrice, avaxPriceOld) => {
           twoDayHistory?.txCount ?? 0
         )
 
-        const currentLiquidityUSD = data?.totalLiquidity * avaxPrice * data?.derivedAVAX  // TODO: do we need to remove this * avaxPrice
-        const oldLiquidityUSD = oneDayHistory?.totalLiquidity * avaxPriceOld * oneDayHistory?.derivedAVAX  // TODO: do we need to remove this * avaxPriceOld
+        const currentLiquidityUSD = data?.totalLiquidity * avaxPrice * data?.derivedAVAX
+        const oldLiquidityUSD = oneDayHistory?.totalLiquidity * avaxPriceOld * oneDayHistory?.derivedAVAX
 
         // percent changes
         const priceChangeUSD = getPercentChange(
@@ -401,8 +401,8 @@ const getTokenData = async (address, avaxPrice, avaxPriceOld) => {
       parseFloat(oneDayData?.derivedAVAX ?? 0) * avaxPriceOld
     )
 
-    const currentLiquidityUSD = data?.totalLiquidity * avaxPrice * data?.derivedAVAX  // TODO: do we need to remove this * avaxPrice
-    const oldLiquidityUSD = oneDayData?.totalLiquidity * avaxPriceOld * oneDayData?.derivedAVAX  // TODO: do we need to remove this * avaxPriceOld
+    const currentLiquidityUSD = data?.totalLiquidity * avaxPrice * data?.derivedAVAX
+    const oldLiquidityUSD = oneDayData?.totalLiquidity * avaxPriceOld * oneDayData?.derivedAVAX
 
     // set data
     data.priceUSD = data?.derivedAVAX * avaxPrice

--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -19,7 +19,6 @@ import { FEE_WARNING_TOKENS } from '../constants'
 import { BasicLink } from '../components/Link'
 import { useMedia } from 'react-use'
 import Search from '../components/Search'
-import { useEthPrice } from '../contexts/GlobalData'
 
 const AccountWrapper = styled.div`
   background-color: rgba(255, 255, 255, 0.2);
@@ -130,19 +129,17 @@ function AccountPage({ account }) {
     return total + position.fees.sum
   }, 0)
 
-  const [ethPrice] = useEthPrice()
-
   const positionValue = useMemo(() => {
     return dynamicPositions
       ? dynamicPositions.reduce((total, position) => {
         return (
           total +
           (parseFloat(position?.liquidityTokenBalance) / parseFloat(position?.pair?.totalSupply)) *
-          position?.pair?.reserveUSD * ethPrice
+          position?.pair?.reserveUSD
         )
       }, 0)
       : null
-  }, [dynamicPositions, ethPrice])
+  }, [dynamicPositions])
 
   useEffect(() => {
     window.scrollTo({

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -24,7 +24,7 @@ import { useMedia } from 'react-use'
 import DoubleTokenLogo from '../components/DoubleLogo'
 import TokenLogo from '../components/TokenLogo'
 import { Hover } from '../components'
-import { useEthPrice } from '../contexts/GlobalData'
+import { useAvaxPrice } from '../contexts/GlobalData'
 import Warning from '../components/Warning'
 import { usePathDismissed, useSavedPairs } from '../contexts/LocalStorage'
 
@@ -168,12 +168,12 @@ function PairPage({ pairAddress, history }) {
       : '-'
 
   // token data for usd
-  const [ethPrice] = useEthPrice()
+  const [avaxPrice] = useAvaxPrice()
   const token0USD =
-    token0?.derivedETH && ethPrice ? formattedNum(parseFloat(token0.derivedETH) * parseFloat(ethPrice), true) : ''
+    token0?.derivedAVAX && avaxPrice ? formattedNum(parseFloat(token0.derivedAVAX) * parseFloat(avaxPrice), true) : ''
 
   const token1USD =
-    token1?.derivedETH && ethPrice ? formattedNum(parseFloat(token1.derivedETH) * parseFloat(ethPrice), true) : ''
+    token1?.derivedAVAX && avaxPrice ? formattedNum(parseFloat(token1.derivedAVAX) * parseFloat(avaxPrice), true) : ''
 
   // rates
   const token0Rate = reserve0 && reserve1 ? formattedNum(reserve1 / reserve0) : '-'
@@ -313,7 +313,7 @@ function PairPage({ pairAddress, history }) {
                   <TokenLogo address={token0?.id} size={'16px'} />
                   <TYPE.main fontSize={'16px'} lineHeight={1} fontWeight={500} ml={'4px'}>
                     {token0 && token1
-                      ? `1 ${formattedSymbol0} = ${token0Rate} ${formattedSymbol1} ${parseFloat(token0?.derivedETH) ? '(' + token0USD + ')' : ''
+                      ? `1 ${formattedSymbol0} = ${token0Rate} ${formattedSymbol1} ${parseFloat(token0?.derivedAVAX) ? '(' + token0USD + ')' : ''
                       }`
                       : '-'}
                   </TYPE.main>
@@ -324,7 +324,7 @@ function PairPage({ pairAddress, history }) {
                   <TokenLogo address={token1?.id} size={'16px'} />
                   <TYPE.main fontSize={'16px'} lineHeight={1} fontWeight={500} ml={'4px'}>
                     {token0 && token1
-                      ? `1 ${formattedSymbol1} = ${token1Rate} ${formattedSymbol0}  ${parseFloat(token1?.derivedETH) ? '(' + token1USD + ')' : ''
+                      ? `1 ${formattedSymbol1} = ${token1Rate} ${formattedSymbol0}  ${parseFloat(token1?.derivedAVAX) ? '(' + token1USD + ')' : ''
                       }`
                       : '-'}
                   </TYPE.main>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -252,24 +252,24 @@ export async function getShareValueOverTime(pairAddress, timestamps) {
         reserve0: result.data[row].reserve0,
         reserve1: result.data[row].reserve1,
         reserveUSD: result.data[row].reserveUSD,
-        token0DerivedETH: result.data[row].token0.derivedETH,
-        token1DerivedETH: result.data[row].token1.derivedETH,
+        token0DerivedAVAX: result.data[row].token0.derivedAVAX,
+        token1DerivedAVAX: result.data[row].token1.derivedAVAX,
         roiUsd: values && values[0] ? sharePriceUsd / values[0]['sharePriceUsd'] : 1,
-        ethPrice: 0,
+        avaxPrice: 0,
         token0PriceUSD: 0,
         token1PriceUSD: 0,
       })
     }
   }
 
-  // add eth prices
+  // add avax prices
   let index = 0
   for (var brow in result?.data) {
     let timestamp = brow.split('b')[1]
     if (timestamp) {
-      values[index].ethPrice = result.data[brow].ethPrice
-      values[index].token0PriceUSD = result.data[brow].ethPrice * values[index].token0DerivedETH
-      values[index].token1PriceUSD = result.data[brow].ethPrice * values[index].token1DerivedETH
+      values[index].avaxPrice = result.data[brow].avaxPrice
+      values[index].token0PriceUSD = result.data[brow].avaxPrice * values[index].token0DerivedAVAX
+      values[index].token1PriceUSD = result.data[brow].avaxPrice * values[index].token1DerivedAVAX
       index += 1
     }
   }

--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -111,12 +111,12 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
   // calculate ownership at ends of window, for end of window we need original LP token balance / new total supply
   // eslint-disable-next-line eqeqeq
   const t0Ownership =
-      positionT0.liquidityTokenTotalSupply != 0
+      positionT0.liquidityTokenTotalSupply !== 0
           ? positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
           : 0
   // eslint-disable-next-line eqeqeq
   const t1Ownership =
-      positionT1.liquidityTokenTotalSupply != 0
+      positionT1.liquidityTokenTotalSupply !== 0
           ? positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
           : 0
 

--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -169,9 +169,9 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
  * @param startDateTimestamp // day to start tracking at
  * @param currentPairData // current stat of the pair
  * @param pairSnapshots // history of entries and exits for lp on this pair
- * @param currentETHPrice // current price of eth used for usd conversions
+ * @param currentAvaxPrice // current price of Avax used for usd conversions
  */
-export async function getHistoricalPairReturns(startDateTimestamp, currentPairData, pairSnapshots, currentETHPrice) {
+export async function getHistoricalPairReturns(startDateTimestamp, currentPairData, pairSnapshots, currentAvaxPrice) {
   // catch case where data not puplated yet
   if (!currentPairData.createdAtTimestamp) {
     return []
@@ -232,8 +232,8 @@ export async function getHistoricalPairReturns(startDateTimestamp, currentPairDa
         reserve0: currentPairData.reserve0,
         reserve1: currentPairData.reserve1,
         reserveUSD: currentPairData.reserveUSD,
-        token0PriceUSD: currentPairData.token0.derivedETH * currentETHPrice,
-        token1PriceUSD: currentPairData.token1.derivedETH * currentETHPrice,
+        token0PriceUSD: currentPairData.token0.derivedAVAX * currentAvaxPrice,
+        token1PriceUSD: currentPairData.token1.derivedAVAX * currentAvaxPrice,
       }
     }
 
@@ -261,9 +261,9 @@ export async function getHistoricalPairReturns(startDateTimestamp, currentPairDa
  * For a given pair and user, get the return metrics
  * @param user
  * @param pair
- * @param ethPrice
+ * @param avaxPrice
  */
-export async function getLPReturnsOnPair(user: string, pair, ethPrice: number, snapshots) {
+export async function getLPReturnsOnPair(user: string, pair, avaxPrice: number, snapshots) {
   // initialize values
   const principal = await getPrincipalForUserPerPair(user, pair.id)
   let hodlReturn = 0
@@ -282,9 +282,9 @@ export async function getLPReturnsOnPair(user: string, pair, ethPrice: number, s
     liquidityTokenTotalSupply: pair.totalSupply,
     reserve0: pair.reserve0,
     reserve1: pair.reserve1,
-    reserveUSD: pair.reserveUSD * ethPrice,
-    token0PriceUSD: pair.token0.derivedETH * ethPrice,
-    token1PriceUSD: pair.token1.derivedETH * ethPrice,
+    reserveUSD: pair.reserveUSD,
+    token0PriceUSD: pair.token0.derivedAVAX * avaxPrice,
+    token1PriceUSD: pair.token1.derivedAVAX * avaxPrice,
   }
 
   for (const index in snapshots) {


### PR DESCRIPTION
In this PR I've swapped out all references of `eth` to be `avax` and I've also reverted to using the price information from the subgraph. This PR is blocked by a current PR to the subgraph repo: https://github.com/pangolindex/subgraph/pull/4.

These will need to be vetted and there are a couple TODOs that still need to be sorted out, particularly surrounding areas where I left in (or dropped) multiplying a variable by the `avaxPrice` because I was uncertain if the value being multiplied was supposed to be in AVAX or USD.