### PR TITLE
Collapse coingecko

### DIFF
--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -461,7 +461,7 @@ const collapsing = {
 const getEthPrice = async () => {
   if (!collapsing.active || !collapsing.result || !collapsing.timestamp || new Date().getTime() - collapsing.collapseFor > collapsing.timestamp ) {  
     collapsing.result = new Promise(resolve => {
-      console.log('lead way:', new Date().getTime() - collapsing.collapseFor, collapsing.timestamp )
+      console.log('fresh coingecko request')
       collapsing.timestamp = new Date().getTime()
       const utcCurrentTime = dayjs()
       const utcOneDayBack = utcCurrentTime.subtract(1, 'day').startOf('minute').unix() * 1000

--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -454,7 +454,7 @@ const getGlobalTransactions = async () => {
 const collapsing = {
     active: true,
     result: null,
-    collapseFor: 1000,
+    collapseFor: 5000, // collapse for 1 sec saves all lot of calls.
     timestamp: null
 };
 
@@ -488,20 +488,15 @@ const getEthPrice = async () => {
             break
           }
         }
-        console.log('answering')
+        console.log('answering collapsed requests')
         resolve([ethPrice, ethPriceOneDay, priceChangeETH])
       })
     })    
   } else {
-    console.log('hmmm:', new Date().getTime() - collapsing.collapseFor - collapsing.timestamp )
+    console.log('returning collapsed request')
   }
   return collapsing.result
 }
-
-setTimeout( () => {
-  console.log('get eth');
-  getEthPrice();
-}, 2000)
 
 export const getEthPriceAtTimestamp = async (timestamp) => {
   const utcCurrentTime = Date.now() / 1000


### PR DESCRIPTION
This saves a metric ton of network traffic.

Just by collapsing coingecko requests for 5 seconds.  getEth() is made 4 times at launch instead of once.