### PR TITLE
Fix Double Charts

### DIFF
--- a/src/components/TradingviewChart/index.js
+++ b/src/components/TradingviewChart/index.js
@@ -54,12 +54,12 @@ const TradingViewChart = ({
   const [darkMode] = useDarkModeManager()
   const textColor = darkMode ? 'white' : 'black'
   const previousTheme = usePrevious(darkMode)
-  const previousData = usePrevious(data)
-  const previousBase = usePrevious(base)
+  const previousIsUSD = usePrevious(isUSD)
+  const previousUseWeekly = usePrevious(useWeekly)
 
   // reset the chart when required
   useEffect(() => {
-    if (chartCreated && (data !== previousData || base !== previousBase || darkMode !== previousTheme)) {
+    if (chartCreated && (isUSD !== previousIsUSD || useWeekly !== previousUseWeekly || darkMode !== previousTheme)) {
       // remove the tooltip element
       let tooltip = document.getElementById('tooltip-id' + type)
       let node = document.getElementById('test-id' + type)
@@ -67,7 +67,7 @@ const TradingViewChart = ({
       chartCreated.resize(0, 0)
       setChartCreated()
     }
-  }, [chartCreated, data, previousData, base, previousBase, darkMode, previousTheme, type])
+  }, [chartCreated, isUSD, previousIsUSD, useWeekly, previousUseWeekly, darkMode, previousTheme, type])
 
   // if no chart created yet, create one with options and add to DOM manually
   useEffect(() => {


### PR DESCRIPTION
This allows us to re-render appropriately when the user changes the volume chart from day/week but does not re-render when data is generally changed. Data is only fetched once, and does not update live. Previously we watched data knowing that it would be changed when the weekly/daily option was changed and can be more clearly watched this way.