### PR TITLE
Optimize Chart Start Times

### DIFF
--- a/src/contexts/PairData.js
+++ b/src/contexts/PairData.js
@@ -497,8 +497,12 @@ export function useHourlyRateData(pairAddress, timeWindow) {
   useEffect(() => {
     const currentTime = dayjs.utc()
     const windowSize = timeWindow === timeframeOptions.MONTH ? 'month' : 'week'
+
+    // February 8th 2021 - Pangolin Factory is created
     const startTime =
-      timeWindow === timeframeOptions.ALL_TIME ? 1589760000 : currentTime.subtract(1, windowSize).startOf('hour').unix()
+      timeWindow === timeframeOptions.ALL_TIME
+        ? dayjs('2021-02-08').startOf('day').unix()
+        : currentTime.subtract(1, windowSize).startOf('hour').unix()
 
     async function fetch() {
       let data = await getHourlyRateData(pairAddress, startTime, latestBlock)

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -705,7 +705,7 @@ export function useTokenPriceData(tokenAddress, timeWindow, interval = 3600) {
     // February 8th 2021 - Pangolin Factory is created
     const startTime =
       timeWindow === timeframeOptions.ALL_TIME
-        ? dayjs('2021-02-07').unix() // TODO: Investigate why this works, but 2021-02-08 will throw "Syntax Error: Expected Name, found }"
+        ? dayjs('2021-02-08').startOf('day').unix()
         : currentTime.subtract(1, windowSize).startOf('hour').unix()
 
     async function fetch() {


### PR DESCRIPTION
Avoid attempting to fetch multiple days/months/etc. worth of data before the Pangolin factory was even available with data