### PR TITLE
Optimize All Time initial display

### DIFF
--- a/src/components/TokenChart/index.js
+++ b/src/components/TokenChart/index.js
@@ -87,20 +87,16 @@ const TokenChart = ({ address, color, base }) => {
       ? dailyAll
       : hourlyAll
 
-  // switch to hourly data when switched to week window
+  // defaults when switching window timeframes
   useEffect(() => {
     if (timeWindow === timeframeOptions.WEEK && prevWindow && prevWindow !== timeframeOptions.WEEK) {
       setFrequency(DATA_FREQUENCY.HOUR)
     }
-  }, [prevWindow, timeWindow])
-
-  // switch to daily data if switched to month or all time view
-  useEffect(() => {
     if (timeWindow === timeframeOptions.MONTH && prevWindow && prevWindow !== timeframeOptions.MONTH) {
       setFrequency(DATA_FREQUENCY.DAY)
     }
     if (timeWindow === timeframeOptions.ALL_TIME && prevWindow && prevWindow !== timeframeOptions.ALL_TIME) {
-      setFrequency(DATA_FREQUENCY.DAY)
+      setFrequency(DATA_FREQUENCY.LINE)
     }
   }, [prevWindow, timeWindow])
 


### PR DESCRIPTION
Default to the line chart which loads significantly faster when using the all time view as the hourly data loads in the background.

Also removes a duplicate useEffect watcher