### PR TITLE
Migration Warning & Prompt

### DIFF
--- a/src/components/Warning/index.js
+++ b/src/components/Warning/index.js
@@ -32,7 +32,7 @@ const StyledWarningIcon = styled(AlertTriangle)`
   stroke: red;
 `
 
-export default function Warning({ type, show, setShow, address }) {
+export function ArbitraryWarning({ type, show, setShow, address }) {
   const below800 = useMedia('(max-width: 800px)')
 
   const textContent = below800 ? (
@@ -47,13 +47,13 @@ export default function Warning({ type, show, setShow, address }) {
       </Text>
     </div>
   ) : (
-      <Text fontWeight={500} lineHeight={'145.23%'} mt={'10px'}>
-        Anyone can create and name any ERC-20 token on Avalanche, including creating fake versions of existing tokens and
-        tokens that claim to represent projects that do not have a token. Similar to Etherscan, this site automatically
-        tracks analytics for all ERC-20 tokens independent of token integrity. Please do your own research before
-        interacting with any ERC-20 token.
-      </Text>
-    )
+    <Text fontWeight={500} lineHeight={'145.23%'} mt={'10px'}>
+      Anyone can create and name any ERC-20 token on Avalanche, including creating fake versions of existing tokens and
+      tokens that claim to represent projects that do not have a token. Similar to Etherscan, this site automatically
+      tracks analytics for all ERC-20 tokens independent of token integrity. Please do your own research before
+      interacting with any ERC-20 token.
+    </Text>
+  )
 
   return (
     <WarningWrapper show={show}>
@@ -86,23 +86,51 @@ export default function Warning({ type, show, setShow, address }) {
             </RowBetween>
           </div>
         ) : (
-            <RowBetween style={{ marginTop: '10px' }}>
-              <Hover>
-                <Link
-                  fontWeight={500}
-                  lineHeight={'145.23%'}
-                  color={'#2172E5'}
-                  href={'https://cchain.explorer.avax.network/address/' + address}
-                  target="_blank"
-                >
-                  View {type === 'token' ? 'token' : 'pair'} contract on Etherscan
+          <RowBetween style={{ marginTop: '10px' }}>
+            <Hover>
+              <Link
+                fontWeight={500}
+                lineHeight={'145.23%'}
+                color={'#2172E5'}
+                href={'https://cchain.explorer.avax.network/address/' + address}
+                target="_blank"
+              >
+                View {type === 'token' ? 'token' : 'pair'} contract on Etherscan
               </Link>
-              </Hover>
-              <ButtonDark color={'#f82d3a'} style={{ minWidth: '140px' }} onClick={() => setShow(false)}>
-                I understand
+            </Hover>
+            <ButtonDark color={'#f82d3a'} style={{ minWidth: '140px' }} onClick={() => setShow(false)}>
+              I understand
             </ButtonDark>
-            </RowBetween>
-          )}
+          </RowBetween>
+        )}
+      </AutoColumn>
+    </WarningWrapper>
+  )
+}
+
+export function MigrateWarning({ show }) {
+  return (
+    <WarningWrapper show={show}>
+      <AutoColumn gap="4px">
+        <RowFixed>
+          <StyledWarningIcon />
+          <Text fontWeight={600} lineHeight={'145.23%'} ml={'10px'}>
+            Token Migration Alert
+          </Text>
+        </RowFixed>
+        <Text fontWeight={500} lineHeight={'145.23%'} mt={'10px'}>
+          Due to the introduction of the faster, cheaper, and safer AB bridge, assets bridged via the old AEB bridge are
+          being migrated 1:1 to their new equivalent token. These tokens are still being traded, but should be migrated
+          for ease of integration with Avalanche dapps.
+        </Text>
+        <RowBetween style={{ marginTop: '10px' }}>
+          <div />
+          <Link href={'https://bridge.avax.network/convert'} target="_blank">
+            <ButtonDark color={'#f82d3a'} style={{ minWidth: '140px' }}>
+              Migrate
+            </ButtonDark>
+          </Link>
+        </RowBetween>
       </AutoColumn>
     </WarningWrapper>
   )

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,7 @@
 export const FACTORY_ADDRESS = '0xefa94DE7a4656D787667C749f7E1223D71E9FD88' // new factory
 
 export const WAVAX_ADDRESS = '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7'
+export const PNG_ADDRESS = '0x60781C2586D68229fde47564546784ab3fACA982'
 
 export const BUNDLE_ID = '1'
 
@@ -14,9 +15,13 @@ export const timeframeOptions = {
 
 // token list urls to fetch tokens from - use for warnings on tokens and pairs
 export const SUPPORTED_LIST_URLS__NO_ENS = [
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/aeb.tokenlist.json',
   'https://raw.githubusercontent.com/pangolindex/tokenlists/main/ab.tokenlist.json',
   'https://raw.githubusercontent.com/pangolindex/tokenlists/main/top15.tokenlist.json',
+]
+
+// token list urls to fetch migrated tokens from - use for warnings on tokens and pairs
+export const MIGRATED_LIST_URLS__NO_ENS = [
+  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/aeb.tokenlist.json',
 ]
 
 // hide from overview list

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -25,7 +25,7 @@ import DoubleTokenLogo from '../components/DoubleLogo'
 import TokenLogo from '../components/TokenLogo'
 import { Hover } from '../components'
 import { useEthPrice } from '../contexts/GlobalData'
-import Warning from '../components/Warning'
+import { ArbitraryWarning } from '../components/Warning'
 import { usePathDismissed, useSavedPairs } from '../contexts/LocalStorage'
 
 import { Bookmark, PlusCircle } from 'react-feather'
@@ -204,7 +204,7 @@ function PairPage({ pairAddress, history }) {
     <PageWrapper>
       <ThemedBackground backgroundColor={transparentize(0.6, backgroundColor)} />
       <span />
-      <Warning
+      <ArbitraryWarning
         type={'pair'}
         show={!dismissed && listedTokens && !(listedTokens.includes(token0?.id) && listedTokens.includes(token1?.id))}
         setShow={markAsDismissed}

--- a/src/pages/TokenPage.js
+++ b/src/pages/TokenPage.js
@@ -24,12 +24,12 @@ import CopyHelper from '../components/Copy'
 import { useMedia } from 'react-use'
 import { useDataForList } from '../contexts/PairData'
 import { useEffect } from 'react'
-import Warning from '../components/Warning'
+import { ArbitraryWarning, MigrateWarning } from '../components/Warning'
 import { usePathDismissed, useSavedTokens } from '../contexts/LocalStorage'
 import { Hover, PageWrapper, ContentWrapper, StyledIcon } from '../components'
 import { PlusCircle, Bookmark } from 'react-feather'
 import FormattedName from '../components/FormattedName'
-import { useListedTokens } from '../contexts/Application'
+import { useListedTokens, useMigratedTokens } from '../contexts/Application'
 
 const DashboardWrapper = styled.div`
   width: 100%;
@@ -159,6 +159,7 @@ function TokenPage({ address, history }) {
   const [dismissed, markAsDismissed] = usePathDismissed(history.location.pathname)
   const [savedTokens, addToken] = useSavedTokens()
   const listedTokens = useListedTokens()
+  const migratedTokens = useMigratedTokens()
 
   useEffect(() => {
     window.scrollTo({
@@ -171,12 +172,14 @@ function TokenPage({ address, history }) {
     <PageWrapper>
       <ThemedBackground backgroundColor={transparentize(0.6, backgroundColor)} />
 
-      <Warning
+      <ArbitraryWarning
         type={'token'}
         show={!dismissed && listedTokens && !listedTokens.includes(address)}
         setShow={markAsDismissed}
         address={address}
       />
+      <MigrateWarning show={migratedTokens && migratedTokens.includes(address)} />
+
       <ContentWrapper>
         <RowBetween style={{ flexWrap: 'wrap', alingItems: 'start' }}>
           <AutoRow align="flex-end" style={{ width: 'fit-content' }}>


### PR DESCRIPTION
Directs users to the AB conversion page when viewing old aeb tokens.

Still Needed:
* Full convert url link once available
* Perhaps better sourcing to avoid WAVAX/PNG/other tokens that make it onto the hosted aeb tokenlist