### PR TITLE
Switch to pangolindex/exchange

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -4,7 +4,7 @@ import { HttpLink } from 'apollo-link-http'
 
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/dasconnor/pangolin-dex',
+    uri: 'https://api.thegraph.com/subgraphs/name/pangolindex/exchange',
   }),
   cache: new InMemoryCache(),
   shouldBatch: true,

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -3,7 +3,7 @@ import { FACTORY_ADDRESS, BUNDLE_ID } from '../constants'
 
 export const SUBGRAPH_HEALTH = gql`
   query health {
-    indexingStatusForCurrentVersion(subgraphName: "dasconnor/pangolin-dex") {
+    indexingStatusForCurrentVersion(subgraphName: "pangolindex/exchange") {
       synced
       health
       chains {


### PR DESCRIPTION
include pairs for tracking whilst staked on the accounts page:

HUSKY, USDC.e, LYD, TUSD, GAJ, GDL, MFI, SHIBX, AVE, ELE, FRAX, FXS, START