### PR TITLE
Update cchain block explorer with snowtrace link

### DIFF
--- a/src/components/TxnList/index.js
+++ b/src/components/TxnList/index.js
@@ -304,7 +304,7 @@ function TxnList({ transactions, symbol0Override, symbol1Override, color }) {
         )}
         {!below1080 && (
           <DataText area="account">
-            <Link color={color} external href={'https://cchain.explorer.avax.network/address/' + item.account}>
+            <Link color={color} external href={'https://snowtrace.io/address/' + item.account}>
               {item.account && item.account.slice(0, 6) + '...' + item.account.slice(38, 42)}
             </Link>
           </DataText>

--- a/src/components/Warning/index.js
+++ b/src/components/Warning/index.js
@@ -72,7 +72,7 @@ export function ArbitraryWarning({ type, show, setShow, address }) {
                 fontWeight={500}
                 lineHeight={'145.23%'}
                 color={'#2172E5'}
-                href={'https://cchain.explorer.avax.network/address/' + address}
+                href={'https://snowtrace.io/address/' + address}
                 target="_blank"
               >
                 View {type === 'token' ? 'token' : 'pair'} contract on Etherscan
@@ -92,7 +92,7 @@ export function ArbitraryWarning({ type, show, setShow, address }) {
                 fontWeight={500}
                 lineHeight={'145.23%'}
                 color={'#2172E5'}
-                href={'https://cchain.explorer.avax.network/address/' + address}
+                href={'https://snowtrace.io/address/' + address}
                 target="_blank"
               >
                 View {type === 'token' ? 'token' : 'pair'} contract on Etherscan

--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -173,7 +173,7 @@ function AccountPage({ account }) {
         <RowBetween>
           <TYPE.body>
             <BasicLink to="/accounts">{'Accounts '}</BasicLink>→{' '}
-            <Link lineHeight={'145.23%'} href={'https://cchain.explorer.avax.network/address/' + account} target="_blank">
+            <Link lineHeight={'145.23%'} href={'https://snowtrace.io/address/' + account} target="_blank">
               {' '}
               {account?.slice(0, 42)}{' '}
             </Link>
@@ -184,7 +184,7 @@ function AccountPage({ account }) {
           <RowBetween>
             <span>
               <TYPE.header fontSize={24}>{account?.slice(0, 6) + '...' + account?.slice(38, 42)}</TYPE.header>
-              <Link lineHeight={'145.23%'} href={'https://cchain.explorer.avax.network/address/' + account} target="_blank">
+              <Link lineHeight={'145.23%'} href={'https://snowtrace.io/address/' + account} target="_blank">
                 <TYPE.main fontSize={14}>View on the C-Chain Explorer</TYPE.main>
               </Link>
               <RowFixed gap="8px" justify="flex-start">

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -224,7 +224,7 @@ function PairPage({ pairAddress, history }) {
               style={{ width: 'fit-content' }}
               color={backgroundColor}
               external
-              href={'https://cchain.explorer.avax.network/address/' + pairAddress}
+              href={'https://snowtrace.io/address/' + pairAddress}
             >
               <Text style={{ marginLeft: '.15rem' }} fontSize={'14px'} fontWeight={400}>
                 ({pairAddress.slice(0, 8) + '...' + pairAddress.slice(36, 42)})
@@ -493,7 +493,7 @@ function PairPage({ pairAddress, history }) {
                     </AutoRow>
                   </Column>
                   <ButtonLight color={backgroundColor}>
-                    <Link color={backgroundColor} external href={'https://cchain.explorer.avax.network/address/' + pairAddress}>
+                    <Link color={backgroundColor} external href={'https://snowtrace.io/address/' + pairAddress}>
                       View on the C-Chain Explorer ↗
                     </Link>
                   </ButtonLight>

--- a/src/pages/TokenPage.js
+++ b/src/pages/TokenPage.js
@@ -338,7 +338,7 @@ function TokenPage({ address, history }) {
               style={{ width: 'fit-content' }}
               color={backgroundColor}
               external
-              href={'https://cchain.explorer.avax.network/address/' + address}
+              href={'https://snowtrace.io/address/' + address}
             >
               <Text style={{ marginLeft: '.15rem' }} fontSize={'14px'} fontWeight={400}>
                 ({address.slice(0, 8) + '...' + address.slice(36, 42)})
@@ -625,7 +625,7 @@ function TokenPage({ address, history }) {
                     <Link
                       color={backgroundColor}
                       external
-                      href={'https://cchain.explorer.avax.network/address/' + address}
+                      href={'https://snowtrace.io/address/' + address}
                     >
                       View on the C-Chain Explorer ↗
                     </Link>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -351,10 +351,10 @@ export const setThemeColor = (theme) => document.documentElement.style.setProper
 export const Big = (number) => new BigNumber(number)
 
 export const urls = {
-  showTransaction: (tx) => `https://cchain.explorer.avax.network/tx/${tx}/`,
-  showAddress: (address) => `https://cchain.explorer.avax.network/address/${address}/`,
-  showToken: (address) => `https://cchain.explorer.avax.network/token/${address}/`,
-  showBlock: (block) => `https://cchain.explorer.avax.network/blocks/${block}/`,
+  showTransaction: (tx) => `https://snowtrace.io/tx/${tx}/`,
+  showAddress: (address) => `https://snowtrace.io/address/${address}/`,
+  showToken: (address) => `https://snowtrace.io/token/${address}/`,
+  showBlock: (block) => `https://snowtrace.io/blocks/${block}/`,
 }
 
 export const formatTime = (unix) => {


### PR DESCRIPTION
### Note
Today, a new tool joins the suite of Avalanche infrastructure with SnowTrace, an implementation of Etherscan custom-built for the Avalanche blockchain.

[SnowTrace](https://snowtrace.io/) replaces the existing [Avalanche C-Chain Explorer](https://cchain.explorer.avax.network) to deliver a more highly-performant, feature-filled experience for the global community of Avalanche developers and users.

### What's New

- Updated all the cchain explorer links from https://cchain.explorer.avax.network/ to https://snowtrace.io/ 
