### PR TITLE
Update C-Chain to Snowtrace

### DIFF
--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -185,7 +185,7 @@ function AccountPage({ account }) {
             <span>
               <TYPE.header fontSize={24}>{account?.slice(0, 6) + '...' + account?.slice(38, 42)}</TYPE.header>
               <Link lineHeight={'145.23%'} href={'https://snowtrace.io/address/' + account} target="_blank">
-                <TYPE.main fontSize={14}>View on the C-Chain Explorer</TYPE.main>
+                <TYPE.main fontSize={14}>View on the Snowtrace Explorer</TYPE.main>
               </Link>
               <RowFixed gap="8px" justify="flex-start">
                 <TYPE.body>Or track on</TYPE.body>

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -494,7 +494,7 @@ function PairPage({ pairAddress, history }) {
                   </Column>
                   <ButtonLight color={backgroundColor}>
                     <Link color={backgroundColor} external href={'https://snowtrace.io/address/' + pairAddress}>
-                      View on the C-Chain Explorer ↗
+                      View on the Snowtrace Explorer ↗
                     </Link>
                   </ButtonLight>
                 </TokenDetailsLayout>

--- a/src/pages/TokenPage.js
+++ b/src/pages/TokenPage.js
@@ -627,7 +627,7 @@ function TokenPage({ address, history }) {
                       external
                       href={'https://snowtrace.io/address/' + address}
                     >
-                      View on the C-Chain Explorer ↗
+                      View on the Snowtrace Explorer ↗
                     </Link>
                   </ButtonLight>
                 </TokenDetailsLayout>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -354,7 +354,7 @@ export const urls = {
   showTransaction: (tx) => `https://snowtrace.io/tx/${tx}/`,
   showAddress: (address) => `https://snowtrace.io/address/${address}/`,
   showToken: (address) => `https://snowtrace.io/token/${address}/`,
-  showBlock: (block) => `https://snowtrace.io/blocks/${block}/`,
+  showBlock: (block) => `https://snowtrace.io/block/${block}/`,
 }
 
 export const formatTime = (unix) => {


### PR DESCRIPTION
### What's New

- Updated texts with `C-Chain` to `Snowtrace`
- Updated `showBlock` url with `block` instead of `blocks`