### PR TITLE
Utilize single Pangolin tokenlist

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -18,16 +18,7 @@ export const timeframeOptions = {
 
 // token list urls to fetch tokens from - use for warnings on tokens and pairs
 export const SUPPORTED_LIST_URLS__NO_ENS = [
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/ab.tokenlist.json',
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/aeb.tokenlist.json',
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/defi.tokenlist.json',
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/stablecoin.tokenlist.json',
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/top15.tokenlist.json',
-]
-
-// token list urls to fetch migrated tokens from - use for warnings on tokens and pairs
-export const MIGRATED_LIST_URLS__NO_ENS = [
-  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/aeb.tokenlist.json',
+  'https://raw.githubusercontent.com/pangolindex/tokenlists/main/pangolin.tokenlist.json',
 ]
 
 // hide from overview list
@@ -48,6 +39,26 @@ export const OVERVIEW_TOKEN_BLACKLIST = [
   '0x99519acb025a0e0d44c3875a4bbf03af65933627', // YFI
 ]
 
+export const AEB_TOKEN_ADDRESSES = [
+  '0xf20d962a6c8f70c731bd838a3a388d7d48fa6e15',
+  '0xe54eb2c3009fa411bf24fb017f9725b973ce36f0',
+  '0x8ce2dee54bb9921a2ae0a63dbb2df8ed88b91dd9',
+  '0x6b329326e0f6b95b93b52229b213334278d6f277',
+  '0xaeb044650278731ef3dc244692ab9f64c78ffaea',
+  '0xb3fe5374f67d7a22886a0ee082b2e2f9d2651651',
+  '0xba7deebbfc5fa1100fb055a87773e1e99cd3507a',
+  '0x46c54b16af7747067f412c78ebadae203a26ada0',
+  '0xe1463e8991c8a62e64b77b5fb6b22f190344c2a9',
+  '0x39cf1bd5f15fb22ec3d9ff86b0727afc203427cc',
+  '0x68e44c4619db40ae1a0725e77c02587bc8fbd1c9',
+  '0xde3a24028580884448a5397872046a019649b084',
+  '0x390ba0fb0bd3aa2a5484001606329701148074e6',
+  '0xc84d7bff2555955b44bdf6a307180810412d751b',
+  '0xf39f9671906d8630812f9d9863bbef5d523c84ab',
+  '0x408d4cd0adb7cebd1f1a1c33a0ba2098e1295bab',
+  '0x99519acb025a0e0d44c3875a4bbf03af65933627',
+]
+
 // pair blacklist
 export const PAIR_BLACKLIST = []
 
@@ -56,7 +67,7 @@ export const PAIR_BLACKLIST = []
  */
 export const FEE_WARNING_TOKENS = []
 
-export const PAIR_CHART_VIEW_OPTIONS  = {
+export const PAIR_CHART_VIEW_OPTIONS = {
   VOLUME: 'Volume',
   LIQUIDITY: 'Liquidity',
   RATE0: 'Rate 0',

--- a/src/contexts/Application.js
+++ b/src/contexts/Application.js
@@ -1,11 +1,5 @@
 import React, { createContext, useContext, useReducer, useMemo, useCallback, useState, useEffect } from 'react'
-import {
-  timeframeOptions,
-  SUPPORTED_LIST_URLS__NO_ENS,
-  MIGRATED_LIST_URLS__NO_ENS,
-  WAVAX_ADDRESS,
-  PNG_ADDRESS,
-} from '../constants'
+import { timeframeOptions, SUPPORTED_LIST_URLS__NO_ENS } from '../constants'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import getTokenList from '../utils/tokenLists'
@@ -17,12 +11,10 @@ const UPDATE = 'UPDATE'
 const UPDATE_TIMEFRAME = 'UPDATE_TIMEFRAME'
 const UPDATE_SESSION_START = 'UPDATE_SESSION_START'
 const UPDATED_SUPPORTED_TOKENS = 'UPDATED_SUPPORTED_TOKENS'
-const UPDATED_MIGRATED_TOKENS = 'UPDATED_MIGRATED_TOKENS'
 const UPDATE_LATEST_BLOCK = 'UPDATE_LATEST_BLOCK'
 const UPDATE_HEAD_BLOCK = 'UPDATE_HEAD_BLOCK'
 
 const SUPPORTED_TOKENS = 'SUPPORTED_TOKENS'
-const MIGRATED_TOKENS = 'MIGRATED_TOKENS'
 const TIME_KEY = 'TIME_KEY'
 const CURRENCY = 'CURRENCY'
 const SESSION_START = 'SESSION_START'
@@ -83,14 +75,6 @@ function reducer(state, { type, payload }) {
       }
     }
 
-    case UPDATED_MIGRATED_TOKENS: {
-      const { migratedTokens } = payload
-      return {
-        ...state,
-        [MIGRATED_TOKENS]: migratedTokens,
-      }
-    }
-
     default: {
       throw Error(`Unexpected action type in DataContext reducer: '${type}'.`)
     }
@@ -142,15 +126,6 @@ export default function Provider({ children }) {
     })
   }, [])
 
-  const updateMigratedTokens = useCallback((migratedTokens) => {
-    dispatch({
-      type: UPDATED_MIGRATED_TOKENS,
-      payload: {
-        migratedTokens,
-      },
-    })
-  }, [])
-
   const updateLatestBlock = useCallback((block) => {
     dispatch({
       type: UPDATE_LATEST_BLOCK,
@@ -179,7 +154,6 @@ export default function Provider({ children }) {
             updateSessionStart,
             updateTimeframe,
             updateSupportedTokens,
-            updateMigratedTokens,
             updateLatestBlock,
             updateHeadBlock,
           },
@@ -190,7 +164,6 @@ export default function Provider({ children }) {
           updateTimeframe,
           updateSessionStart,
           updateSupportedTokens,
-          updateMigratedTokens,
           updateLatestBlock,
           updateHeadBlock,
         ]
@@ -316,30 +289,4 @@ export function useListedTokens() {
   }, [updateSupportedTokens, supportedTokens])
 
   return supportedTokens
-}
-
-export function useMigratedTokens() {
-  const [state, { updateMigratedTokens }] = useApplicationContext()
-  const migratedTokens = state?.[MIGRATED_TOKENS]
-
-  useEffect(() => {
-    // WAVAX and PNG should not be included in the migration tokens
-    const excludedTokens = [WAVAX_ADDRESS, PNG_ADDRESS].map((token) => token.toLowerCase())
-    async function fetchList() {
-      const allFetched = await MIGRATED_LIST_URLS__NO_ENS.reduce(async (fetchedTokens, url) => {
-        const tokensSoFar = await fetchedTokens
-        const newTokens = await getTokenList(url)
-        return Promise.resolve([...tokensSoFar, ...newTokens.tokens])
-      }, Promise.resolve([]))
-      const formatted = allFetched
-        ?.map((t) => t.address.toLowerCase())
-        .filter((address) => !excludedTokens.includes(address))
-      updateMigratedTokens(formatted)
-    }
-    if (!migratedTokens) {
-      fetchList()
-    }
-  }, [updateMigratedTokens, migratedTokens])
-
-  return migratedTokens
 }

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -30,8 +30,8 @@ import { usePathDismissed, useSavedPairs } from '../contexts/LocalStorage'
 
 import { Bookmark, PlusCircle } from 'react-feather'
 import FormattedName from '../components/FormattedName'
-import { useListedTokens, useMigratedTokens } from '../contexts/Application'
-import { SWAP_FEE_TO_LP } from '../constants'
+import { useListedTokens } from '../contexts/Application'
+import { AEB_TOKEN_ADDRESSES, SWAP_FEE_TO_LP } from '../constants'
 
 const DashboardWrapper = styled.div`
   width: 100%;
@@ -129,7 +129,6 @@ function PairPage({ pairAddress, history }) {
 
   const transactions = usePairTransactions(pairAddress)
   const backgroundColor = useColor(pairAddress)
-  const migratedTokens = useMigratedTokens()
 
   // liquidity
   const liquidity = trackedReserveUSD
@@ -212,7 +211,7 @@ function PairPage({ pairAddress, history }) {
         setShow={markAsDismissed}
         address={pairAddress}
       />
-      <MigrateWarning show={migratedTokens?.includes(token0?.id) || migratedTokens?.includes(token1?.id)} />
+      <MigrateWarning show={AEB_TOKEN_ADDRESSES.includes(token0?.id) || AEB_TOKEN_ADDRESSES.includes(token1?.id)} />
 
       <ContentWrapperLarge>
         <RowBetween style={{ flexWrap: 'wrap', alingItems: 'start' }}>

--- a/src/pages/TokenPage.js
+++ b/src/pages/TokenPage.js
@@ -31,8 +31,9 @@ import { usePathDismissed, useSavedTokens } from '../contexts/LocalStorage'
 import { Hover, PageWrapper, ContentWrapper, StyledIcon } from '../components'
 import { PlusCircle, Bookmark } from 'react-feather'
 import FormattedName from '../components/FormattedName'
-import { useListedTokens, useMigratedTokens } from '../contexts/Application'
+import { useListedTokens } from '../contexts/Application'
 import METAMASK_IMAGE from '../assets/MetaMask.png'
+import { AEB_TOKEN_ADDRESSES } from '../constants'
 
 const DashboardWrapper = styled.div`
   width: 100%;
@@ -274,7 +275,6 @@ function TokenPage({ address, history }) {
   const [dismissed, markAsDismissed] = usePathDismissed(history.location.pathname)
   const [savedTokens, addToken] = useSavedTokens()
   const listedTokens = useListedTokens()
-  const migratedTokens = useMigratedTokens()
 
   useEffect(() => {
     window.scrollTo({
@@ -325,7 +325,7 @@ function TokenPage({ address, history }) {
         setShow={markAsDismissed}
         address={address}
       />
-      <MigrateWarning show={migratedTokens && migratedTokens.includes(address)} />
+      <MigrateWarning show={AEB_TOKEN_ADDRESSES.includes(address)} />
 
       <ContentWrapper>
         <RowBetween style={{ flexWrap: 'wrap', alingItems: 'start' }}>


### PR DESCRIPTION
Remove reducers etc. and track AEB migration tokens via a static list instead of from the tokenlist. Also replaces the collection of tokenlists used to "whitelist" assets with the single pangolin tokenlist